### PR TITLE
0.0.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,14 +43,11 @@ jobs:
       - name: Run mypy for tests
         run: mypy tests --exclude typing
 
-  # Отдельный джоб специально для проблемного патча 3.9.1
   build-3-9-1:
     runs-on: ubuntu-latest
-    container: python:3.9.1  # Запускаем прямо внутри чистого образа 3.9.1
+    container: python:3.9.1
     steps:
       - uses: actions/checkout@v4
-
-      # Нам больше НЕ НУЖЕН actions/setup-python, так как в контейнере уже стоит 3.9.1!
 
       - name: Cache pip dependencies
         uses: actions/cache@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,17 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
+        os: [ubuntu-latest]
+      exclude:
+        - python-version: '3.9.1'
+          os: ubuntu-latest
+      include:
+        - python-version: '3.9.1'
+          os: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,14 +7,27 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
-        os: [ubuntu-latest]
-      exclude:
-        - python-version: 3.9.1
-          os: ubuntu-latest
-      include:
-        - python-version: 3.9.1
-          os: ubuntu-24.04
+        include:
+          - os: ubuntu-latest
+            python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.9
+          - os: ubuntu-24.04
+            python-version: 3.9.1
+          - os: ubuntu-latest
+            python-version: 3.10
+          - os: ubuntu-latest
+            python-version: 3.11
+          - os: ubuntu-latest
+            python-version: 3.12
+          - os: ubuntu-latest
+            python-version: 3.13
+          - os: ubuntu-latest
+            python-version: 3.14
+          - os: ubuntu-latest
+            python-version: 3.14t
+          - os: ubuntu-latest
+            python-version: 3.15.0-alpha.1
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,31 +3,13 @@ name: Lint
 on: push
 
 jobs:
+  # Основной джоб для современных версий
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
-          - os: ubuntu-20.04
-            python-version: "3.9.1"
-          - os: ubuntu-latest
-            python-version: "3.10"   # <--- Вот здесь была главная проблема
-          - os: ubuntu-latest
-            python-version: "3.11"
-          - os: ubuntu-latest
-            python-version: "3.12"
-          - os: ubuntu-latest
-            python-version: "3.13"
-          - os: ubuntu-latest
-            python-version: "3.14"
-          - os: ubuntu-latest
-            python-version: "3.14t"
-          - os: ubuntu-latest
-            python-version: "3.15.0-alpha.1"
+        # Вернули чистый список без 3.9.1
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,9 +24,39 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ github.workflow }}-
-            ${{ runner.os }}-pip-${{ github.workflow }}-
+
+      - name: Install dependencies
+        run: pip install -r requirements_dev.txt
+
+      - name: Install the library
+        run: pip install .
+
+      - name: Run ruff
+        run: ruff check transfunctions
+
+      - name: Run ruff for tests
+        run: ruff check tests
+
+      - name: Run mypy
+        run: mypy --strict transfunctions
+
+      - name: Run mypy for tests
+        run: mypy tests --exclude typing
+
+  # Отдельный джоб специально для проблемного патча 3.9.1
+  build-3-9-1:
+    runs-on: ubuntu-latest
+    container: python:3.9.1  # Запускаем прямо внутри чистого образа 3.9.1
+    steps:
+      - uses: actions/checkout@v4
+
+      # Нам больше НЕ НУЖЕН actions/setup-python, так как в контейнере уже стоит 3.9.1!
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: debian-pip-3.9.1-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Install dependencies
         run: pip install -r requirements_dev.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Run mypy for tests
         run: mypy tests --exclude typing
 
+  # A separate job specifically for bug testing in Python 3.9.1 (Linux only)
   build-3-9-1:
     runs-on: ubuntu-latest
     container: python:3.9.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,25 +9,25 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: "3.9"
           - os: ubuntu-20.04
             python-version: "3.9.1"
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: "3.10"   # <--- Вот здесь была главная проблема
           - os: ubuntu-latest
-            python-version: 3.11
+            python-version: "3.11"
           - os: ubuntu-latest
-            python-version: 3.12
+            python-version: "3.12"
           - os: ubuntu-latest
-            python-version: 3.13
+            python-version: "3.13"
           - os: ubuntu-latest
-            python-version: 3.14
+            python-version: "3.14"
           - os: ubuntu-latest
-            python-version: 3.14t
+            python-version: "3.14t"
           - os: ubuntu-latest
-            python-version: 3.15.0-alpha.1
+            python-version: "3.15.0-alpha.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,8 +28,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
           restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ github.workflow }}-
             ${{ runner.os }}-pip-${{ github.workflow }}-
 
       - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
         os: [ubuntu-latest]
-      exclude:
+      exclude:  # ← На уровне matrix (отступ 6 пробелов от strategy)
         - python-version: '3.9.1'
           os: ubuntu-latest
-      include:
+      include:  # ← На уровне matrix
         - python-version: '3.9.1'
           os: ubuntu-24.04
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
             python-version: 3.8
           - os: ubuntu-latest
             python-version: 3.9
-          - os: ubuntu-24.04
+          - os: ubuntu-20.04
             python-version: 3.9.1
           - os: ubuntu-latest
             python-version: 3.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-20.04
-            python-version: 3.9.1
+            python-version: "3.9.1"
           - os: ubuntu-latest
             python-version: 3.10
           - os: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
+        python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
         os: [ubuntu-latest]
-      exclude:  # ← На уровне matrix (отступ 6 пробелов от strategy)
-        - python-version: '3.9.1'
+      exclude:
+        - python-version: 3.9.1
           os: ubuntu-latest
-      include:  # ← На уровне matrix
-        - python-version: '3.9.1'
+      include:
+        - python-version: 3.9.1
           os: ubuntu-24.04
 
     steps:
@@ -34,25 +34,19 @@ jobs:
             ${{ runner.os }}-pip-${{ github.workflow }}-
 
       - name: Install dependencies
-        shell: bash
         run: pip install -r requirements_dev.txt
 
       - name: Install the library
-        shell: bash
         run: pip install .
 
       - name: Run ruff
-        shell: bash
         run: ruff check transfunctions
 
       - name: Run ruff for tests
-        shell: bash
         run: ruff check tests
 
       - name: Run mypy
-        shell: bash
         run: mypy --strict transfunctions
 
       - name: Run mypy for tests
-        shell: bash
         run: mypy tests --exclude typing

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -56,7 +56,7 @@ jobs:
         shell: bash
         run: coverage run --branch --source=transfunctions --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=94
 
-  # 2. A separate job specifically for bug testing in Python 3.9.1 (Linux only)
+  # A separate job specifically for bug testing in Python 3.9.1 (Linux only)
   build-3-9-1:
     runs-on: ubuntu-latest
     container: python:3.9.1

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
+        python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -8,36 +8,36 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.9.1", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15.0-alpha.1"]
 
     steps:
       - uses: actions/checkout@v4
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install the library
-        shell: bash
-        run: pip install .
-
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ github.workflow }}-
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
 
       - name: Install dependencies
         shell: bash
         run: pip install -r requirements_dev.txt
+
+      - name: Install the library
+        shell: bash
+        run: pip install .
 
       - name: Print all libs
         shell: bash
         run: pip list
 
       - name: Run tests and show coverage on the command line
+        shell: bash
         run: |
           coverage run --source=transfunctions --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=94
           coverage xml
@@ -53,4 +53,38 @@ jobs:
         continue-on-error: true
 
       - name: Run tests and show the branch coverage on the command line
+        shell: bash
+        run: coverage run --branch --source=transfunctions --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=94
+
+  # 2. A separate job specifically for bug testing in Python 3.9.1 (Linux only)
+  build-3-9-1:
+    runs-on: ubuntu-latest
+    container: python:3.9.1
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ubuntu-pip-3.9.1-${{ github.workflow }}-${{ hashFiles('requirements_dev.txt') }}
+
+      - name: Install dependencies
+        shell: bash
+        run: pip install -r requirements_dev.txt
+
+      - name: Install the library
+        shell: bash
+        run: pip install .
+
+      - name: Print all libs
+        shell: bash
+        run: pip list
+
+      - name: Run tests and show coverage on the command line
+        shell: bash
+        run: coverage run --source=transfunctions --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=94
+
+      - name: Run tests and show the branch coverage on the command line
+        shell: bash
         run: coverage run --branch --source=transfunctions --omit="*tests*" -m pytest --cache-clear --assert=plain && coverage report -m --fail-under=94

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "transfunctions"
-version = "0.0.11"
+version = "0.0.12"
 authors = [{ name = "Evgeniy Blinov", email = "zheni-b@yandex.ru" }]
 description = 'Say NO to Python fragmentation on sync and async'
 readme = "README.md"

--- a/transfunctions/typing.py
+++ b/transfunctions/typing.py
@@ -12,7 +12,7 @@ if sys.version_info <= (3, 10):
 else:
     from typing import TypeAlias
 
-if sys.version_info <= (3, 9):
+if sys.version_info <= (3, 10):
     from typing import Callable, Coroutine, Generator  # pragma: no cover
 else:
     from collections.abc import Callable, Coroutine, Generator


### PR DESCRIPTION
This is an important update only if you use `Python 3.9.X`.

[A bug](https://github.com/dask/distributed/issues/7956) was discovered in `Python 3.9.1` that caused an exception to occur when importing `transfunction`:

```
Python 3.9.1 (v3.9.1:1e5d33e9b9, Dec  7 2020, 12:44:01)
[Clang 12.0.0 (clang-1200.0.32.27)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from transfunctions import transfunction
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../venv/lib/python3.9/site-packages/transfunctions/__init__.py", line 1, in <module>
    from transfunctions.decorators.superfunction import (
  File ".../venv/lib/python3.9/site-packages/transfunctions/decorators/superfunction.py", line 113, in <module>
    ) -> Union[
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 262, in inner
    return func(*args, **kwds)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 339, in __getitem__
    return self._getitem(self, parameters)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 451, in Union
    parameters = _remove_dups_flatten(parameters)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 231, in _remove_dups_flatten
    return tuple(_deduplicate(params))
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/typing.py", line 205, in _deduplicate
    all_params = set(params)
TypeError: unhashable type: 'list'
>>>
```

This update works around this issue and also adds `Python 3.9.1` to the CI pipeline to catch similar issues in the future.